### PR TITLE
SSL / TLS error with apache-http Dockerfile

### DIFF
--- a/windows-container-samples/apache-http/Dockerfile
+++ b/windows-container-samples/apache-http/Dockerfile
@@ -7,12 +7,14 @@ LABEL Description="Apache" Vendor="Apache Software Foundation" Version="2.4.23"
 
 RUN powershell -Command \
 	$ErrorActionPreference = 'Stop'; \
-	Invoke-WebRequest -Method Get -Uri https://www.apachelounge.com/download/VC14/binaries/httpd-2.4.23-win64-VC14.zip -OutFile c:\apache.zip ; \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+	Invoke-WebRequest -Method Get -Uri https://home.apache.org/~steffenal/VC14/binaries/httpd-2.4.38-win64-VC14.zip -OutFile c:\apache.zip ; \
 	Expand-Archive -Path c:\apache.zip -DestinationPath c:\ ; \
 	Remove-Item c:\apache.zip -Force
 
 RUN powershell -Command \
 	$ErrorActionPreference = 'Stop'; \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Method Get -Uri "https://download.microsoft.com/download/9/3/F/93FCF1E7-E6A4-478B-96E7-D4B285925B00/vc_redist.x64.exe" -OutFile c:\vc_redist.x64.exe ; \
 	start-Process c:\vc_redist.x64.exe -ArgumentList '/quiet' -Wait ; \
 	Remove-Item c:\vc_redist.x64.exe -Force


### PR DESCRIPTION
Correcting SSL / TLS exception cause by Invoke-WebRequest.
Initial error when building docker image was:
```
PS D:\docker-data\apache-http-win> docker build -t apache-http-win:latest .
Sending build context to Docker daemon   2.56kB
Step 1/6 : FROM microsoft/windowsservercore
 ---> ea9f7aa13d03
Step 2/6 : LABEL Description="Apache" Vendor="Apache Software Foundation" Version="2.4.23"
 ---> Using cache
 ---> ad49d4af1b13
Step 3/6 : RUN powershell -Command      $ErrorActionPreference = 'Stop';        Invoke-WebRequest -Uri https://www.apachelounge.com/download/VC14/binaries/httpd-2.4.23-win64-VC14.zip -OutFile c:\apache.zip ;         Expand-Archive -Path c:\apache.zip -DestinationPath c:\ ;       Remove-Item c:\apache.zip -Force
 ---> Running in c1bdf1b29820
Invoke-WebRequest : The request was aborted: Could not create SSL/TLS secure
channel.
At line:1 char:34
+ ... e = 'Stop'; Invoke-WebRequest -Uri https://www.apachelounge.com/downl ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (System.Net.HttpWebRequest:Htt
   pWebRequest) [Invoke-WebRequest], WebException
    + FullyQualifiedErrorId : WebCmdletWebResponseException,Microsoft.PowerShe
   ll.Commands.InvokeWebRequestCommand
```

Adding `[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;` correct the http request during docker build phase

Correcting the path to the apache binaries